### PR TITLE
Replaced MS by ms

### DIFF
--- a/OpenYeeLightUI/Pages/LightPage.cs
+++ b/OpenYeeLightUI/Pages/LightPage.cs
@@ -128,7 +128,7 @@ namespace OpenYeeLightUI.Pages
 
         private void SmoothnessTrackBar_ValueChanged(object sender, EventArgs e)
         {
-            SmoothnessProcentLabel.Text = $"{SmoothnessTrackBar.Value}0MS";
+            SmoothnessProcentLabel.Text = $"{SmoothnessTrackBar.Value}0ms";
         }
 
         private void FeedbackButton_Click(object sender, EventArgs e)


### PR DESCRIPTION
Ms would be Mega seconds (10^6 seconds)
ms is the correct unit (10^-3 seconds